### PR TITLE
PHP libraries, examples and tests

### DIFF
--- a/examples/direct/TextConsumer.php
+++ b/examples/direct/TextConsumer.php
@@ -1,0 +1,35 @@
+#!/usr/bin/php
+<?php
+
+require_once('Thrift/Thrift.php');
+require_once('Thrift/protocol/TBinaryProtocol.php');
+require_once('Thrift/transport/TSocket.php');
+require_once('Thrift/transport/TBufferedTransport.php');
+require_once(dirname(__FILE__). '/../../gen-php/jp/JobPool.php');
+
+$socket = new TSocket('localhost', 9090);
+$transport = new TBufferedTransport($socket);
+$protocol = new TBinaryProtocol($transport);
+$pool = new JobPoolClient($protocol);
+$transport->open();
+
+while(true) {
+	try {
+		$job = $pool->acquire('text');
+		echo 'I\'m consuming a ' . $job->message . PHP_EOL;
+		$pool->purge('text', $job->id);
+		echo 'I consumed a ' . $job->message . PHP_EOL;
+	}
+	catch (EmptyPool $e) {
+		echo 'Pool is empty :(' . PHP_EOL;
+		break;
+	}
+	catch (Exception $e) {
+		echo $e;
+		exit;
+	}
+}
+
+$transport->close();
+
+?>

--- a/examples/direct/TextProducer.php
+++ b/examples/direct/TextProducer.php
@@ -1,0 +1,27 @@
+#!/usr/bin/php
+<?php
+
+require_once('Thrift/Thrift.php');
+require_once('Thrift/protocol/TBinaryProtocol.php');
+require_once('Thrift/transport/TSocket.php');
+require_once('Thrift/transport/TBufferedTransport.php');
+require_once(dirname(__FILE__). '/../../gen-php/jp/JobPool.php');
+
+try {
+	$socket = new TSocket('localhost', 9090);
+	$transport = new TBufferedTransport($socket);
+	$protocol = new TBinaryProtocol($transport);
+	$pool = new JobPoolClient($protocol);
+	
+	$transport->open();
+	echo 'Adding a pie...' . PHP_EOL;
+	$pool->add('text', 'pie');
+	echo 'I added a pie' . PHP_EOL;
+	$transport->close();
+}
+catch (Exception $e) {
+	echo $e;
+	exit;
+}
+
+?>

--- a/examples/simple/JsonConsumer.php
+++ b/examples/simple/JsonConsumer.php
@@ -1,0 +1,23 @@
+#!/usr/bin/php
+<?php
+
+set_time_limit(0);
+
+$jpRoot = dirname(__FILE__) . '/../../';
+set_include_path(get_include_path() . PATH_SEPARATOR . $jpRoot . 'lib/php' . PATH_SEPARATOR . $jpRoot . 'gen-php/jp');
+require_once('jp/consumer/Json.php');
+require_once('jp/worker/Interface.php');
+
+class JsonQueueWorker implements jp_worker_Interface {
+	/**
+	 * @param array $item
+	 * @return void
+	 */
+	public function processItem($item) {
+		echo 'I consumed: ' . print_r($item, true);
+		return true;
+	}
+}
+
+$processor = new jp_consumer_Json('json', array('poll_interval' => 200), new JsonQueueWorker());
+$processor->run();

--- a/examples/simple/JsonProducer.php
+++ b/examples/simple/JsonProducer.php
@@ -1,0 +1,13 @@
+#!/usr/bin/php
+<?php
+
+$jpRoot = dirname(__FILE__) . '/../../';
+set_include_path(get_include_path() . PATH_SEPARATOR . $jpRoot . 'lib/php' . PATH_SEPARATOR . $jpRoot . 'gen-php/jp');
+require_once('jp/producer/Json.php');
+
+$producer = new jp_producer_Json('json');
+$doc = array('language' => 'php', 'api' => 'simple', 'format' => 'json');
+
+for($i = 0; $i < 100; $i++) {
+	$producer->add($doc);
+}

--- a/examples/simple/TextConsumer.php
+++ b/examples/simple/TextConsumer.php
@@ -1,0 +1,19 @@
+#!/usr/bin/php
+<?php
+
+set_time_limit(0);
+
+$jpRoot = dirname(__FILE__) . '/../../';
+set_include_path(get_include_path() . PATH_SEPARATOR . $jpRoot . 'lib/php' . PATH_SEPARATOR . $jpRoot . 'gen-php/jp');
+require_once('jp/consumer/Text.php');
+require_once('jp/worker/Interface.php');
+
+class TextQueueWorker implements jp_worker_Interface {
+	public function processItem($item) {
+		echo 'I consumed a ' . $item . PHP_EOL;
+		return true;
+	}
+}
+
+$consumer = new jp_consumer_Text('text', array('poll_interval' => 200), new TextQueueWorker());
+$consumer->run();

--- a/examples/simple/TextProducer.php
+++ b/examples/simple/TextProducer.php
@@ -1,0 +1,12 @@
+#!/usr/bin/php
+<?php
+
+$jpRoot = dirname(__FILE__) . '/../../';
+set_include_path(get_include_path() . PATH_SEPARATOR . $jpRoot . 'lib/php' . PATH_SEPARATOR . $jpRoot . 'gen-php/jp');
+require_once('jp/producer/Text.php');
+
+$producer = new jp_producer_Text('text');
+
+for($i = 0; $i < 100; $i++) {
+	$producer->add('simple pizza');
+}

--- a/examples/simple/ThriftConsumer.php
+++ b/examples/simple/ThriftConsumer.php
@@ -1,0 +1,21 @@
+#!/usr/bin/php
+<?php
+
+set_time_limit(0);
+
+$jpRoot = dirname(__FILE__) . '/../../';
+set_include_path(get_include_path() . PATH_SEPARATOR . $jpRoot . 'lib/php' . PATH_SEPARATOR . $jpRoot . 'gen-php/jp');
+$GLOBALS['THRIFT_ROOT'] = 'Thrift';
+require_once('jp/consumer/Thrift.php');
+require_once('jp/worker/Interface.php');
+require_once(dirname(__FILE__) . '/../gen-php/example/example_types.php');
+
+class ThriftQueueWorker implements jp_worker_Interface {
+	public function processItem($message) {
+		echo 'I consumed: ' . print_r($message, true);
+		return true;
+	}
+}
+
+$processor = new jp_consumer_Thrift('thrift', array('poll_interval' => 200), new ThriftQueueWorker(), 'ExampleData');
+$processor->run();

--- a/examples/simple/ThriftProducer.php
+++ b/examples/simple/ThriftProducer.php
@@ -1,0 +1,18 @@
+#!/usr/bin/php
+<?php
+
+$jpRoot = dirname(__FILE__) . '/../../';
+set_include_path(get_include_path() . PATH_SEPARATOR . $jpRoot . 'lib/php' . PATH_SEPARATOR . $jpRoot . 'gen-php/jp');
+$GLOBALS['THRIFT_ROOT'] = 'Thrift';
+require_once('jp/producer/Thrift.php');
+require_once(dirname(__FILE__) . '/../gen-php/example/example_types.php');
+
+$producer = new jp_producer_Thrift('thrift');
+$doc = new ExampleData();
+$doc->language = 'php';
+$doc->api = 'simple';
+$doc->format = 'thrift';
+
+for($i = 0; $i < 100; $i++) {
+	$producer->add($doc);
+}

--- a/lib/php/jp/Client.php
+++ b/lib/php/jp/Client.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @throws InvalidArgumentException
+ * @package jp
+ */
+abstract class jp_Client {
+	/**
+	 * @var array
+	 */
+	protected $_options = array();
+
+	/**
+	 * @var string
+	 */
+	protected $_queue;
+
+	/**
+	 * @var JobPoolClient|object
+	 */
+	protected $_client;
+
+	/**
+	 * @throws InvalidArgumentException
+	 * @param string $queue
+	 * @param array $options
+	 * @return void
+	 */
+	public function __construct($queue, $options = array()) {
+		if(!isset($options['host'])) $options['host'] = 'localhost';
+		if(!isset($options['port'])) $options['port'] = 9090;
+		if(!is_string($queue)) throw new InvalidArgumentException();
+
+		$this->_queue = $queue;
+		$this->_options = $options;
+
+		if(isset($options['client'])) {
+			$this->_client = $this->_options['client'];
+		}
+		else {
+			require_once 'Thrift/Thrift.php';
+			require_once 'Thrift/protocol/TBinaryProtocol.php';
+			require_once 'Thrift/transport/TSocket.php';
+			require_once 'Thrift/transport/TBufferedTransport.php';
+			require_once 'JobPool.php';
+			
+			$socket = new TSocket($this->_options['host'], $this->_options['port']);
+			$transport = new TBufferedTransport($socket);
+			$protocol = new TBinaryProtocol($transport);
+			$this->_client = new JobPoolClient($protocol);
+			$transport->open();
+		}
+	}
+}

--- a/lib/php/jp/consumer/Abstract.php
+++ b/lib/php/jp/consumer/Abstract.php
@@ -1,0 +1,62 @@
+<?php
+
+require_once 'jp/Client.php';
+
+/**
+ * @package jp.consumer
+ */
+abstract class jp_consumer_Abstract extends jp_Client {
+	/**
+	 * @var jp_worker_Interface
+	 */
+	protected $_worker;
+
+	/**
+	 * @throws InvalidArgumentException
+	 * @param string $queue
+	 * @param array $options
+	 * @param jp_worker_Abstract $worker
+	 * @return void
+	 */
+	public function __construct($queue, $options = array(), jp_worker_Interface $worker = null) {
+		if(!$worker) throw new InvalidArgumentException('Expecting worker');
+		if(!isset($options['poll_interval'])) $options['poll_interval'] = 1000000;
+		else $options['poll_interval'] = $options['poll_interval'] * 1000;
+		$this->_worker = $worker;
+		parent::__construct($queue, $options);
+	}
+
+	/**
+	 * @return int
+	 */
+	public function run() {
+		$i = 0;
+
+		try {
+			while(true) {
+				$this->consume();
+				if($this->_options['poll_interval'] > 0) usleep($this->_options['poll_interval']);
+				++$i;
+			}
+		}
+		catch(EmptyPool $e) { }
+
+		return $i;
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function consume() {
+		$job = $this->_client->acquire($this->_queue);
+		$result = $this->_worker->processItem($this->translate($job->message));
+		if($result) $this->_client->purge($this->_queue, $job->id);
+	}
+
+	/**
+	 * @abstract
+	 * @param string $message
+	 * @return void
+	 */
+	abstract protected function translate($message);
+}

--- a/lib/php/jp/consumer/Json.php
+++ b/lib/php/jp/consumer/Json.php
@@ -1,0 +1,16 @@
+<?php
+
+require_once 'jp/consumer/Abstract.php';
+
+/**
+ * @package jp.consumer
+ */
+class jp_consumer_Json extends jp_consumer_Abstract {
+	/**
+	 * @param string $message
+	 * @return array
+	 */
+	protected function translate($message) {
+		return json_decode($message, true);
+	}
+}

--- a/lib/php/jp/consumer/Text.php
+++ b/lib/php/jp/consumer/Text.php
@@ -1,0 +1,16 @@
+<?php
+
+require_once 'jp/consumer/Abstract.php';
+
+/**
+ * @package jp.consumer
+ */
+class jp_consumer_Text extends jp_consumer_Abstract {
+	/**
+	 * @param string $message
+	 * @return string
+	 */
+	protected function translate($message) {
+		return $message;
+	}
+}

--- a/lib/php/jp/consumer/Thrift.php
+++ b/lib/php/jp/consumer/Thrift.php
@@ -1,0 +1,54 @@
+<?php
+
+require_once 'jp/consumer/Abstract.php';
+
+/**
+ * @throws InvalidArgumentException
+ * @package jp.consumer
+ */
+class jp_consumer_Thrift extends jp_consumer_Abstract {
+	/**
+	 * @var TMemoryBuffer
+	 */
+	protected $_transport;
+
+	/**
+	 * @var TBinaryProtocol
+	 */
+	protected $_protocol;
+
+	/**
+	 * @var string
+	 */
+	protected $_className;
+
+	/**
+	 * @throws InvalidArgumentException
+	 * @param string $queue
+	 * @param array $options
+	 * @param string $className
+	 * @return void
+	 */
+	public function __construct($queue, $options = array(), jp_worker_Interface $worker = null, $className = '') {
+		require_once 'Thrift/protocol/TBinaryProtocol.php';
+		require_once 'Thrift/transport/TMemoryBuffer.php';
+		if(empty($className)) throw new InvalidArgumentException();
+		$protocolFactory = new TBinaryProtocolFactory();
+		$this->_transport = new TMemoryBuffer();
+		$this->_protocol = $protocolFactory->getProtocol($this->_transport);
+		$this->_className = $className;
+		parent::__construct($queue, $options, $worker);
+	}
+
+	/**
+	 * @param string $message
+	 * @return object
+	 */
+	protected function translate($message) {
+		$class = new ReflectionClass($this->_className);
+		$object = $class->newInstanceArgs();
+		$this->_transport->write($message);
+		$object->read($this->_protocol);
+		return $object;
+	}
+}

--- a/lib/php/jp/producer/Abstract.php
+++ b/lib/php/jp/producer/Abstract.php
@@ -1,0 +1,23 @@
+<?php
+
+require_once 'jp/Client.php';
+
+/**
+ * @package jp.producer
+ */
+abstract class jp_producer_Abstract extends jp_Client {
+	/**
+	 * @param string $message
+	 * @return void
+	 */
+	public function add($message) {
+		return $this->_client->add($this->_queue, $this->translate($message));
+	}
+
+	/**
+	 * @abstract
+	 * @param string|array|object $message
+	 * @return string
+	 */
+	abstract protected function translate($message);
+}

--- a/lib/php/jp/producer/Json.php
+++ b/lib/php/jp/producer/Json.php
@@ -1,0 +1,16 @@
+<?php
+
+require_once 'jp/producer/Abstract.php';
+
+/**
+ * @package jp.producer
+ */
+class jp_producer_Json extends jp_producer_Abstract {
+	/**
+	 * @param array $message
+	 * @return string
+	 */
+	protected function translate($message) {
+		return json_encode($message);
+	}
+}

--- a/lib/php/jp/producer/Text.php
+++ b/lib/php/jp/producer/Text.php
@@ -1,0 +1,16 @@
+<?php
+
+require_once 'jp/producer/Abstract.php';
+
+/**
+ * @package jp.producer
+ */
+class jp_producer_Text extends jp_producer_Abstract {
+	/**
+	 * @param string $message
+	 * @return string
+	 */
+	protected function translate($message) {
+		return $message;
+	}
+}

--- a/lib/php/jp/producer/Thrift.php
+++ b/lib/php/jp/producer/Thrift.php
@@ -1,0 +1,41 @@
+<?php
+
+require_once 'jp/producer/Abstract.php';
+
+/**
+ * @package jp.producer
+ */
+class jp_producer_Thrift extends jp_producer_Abstract {
+	/**
+	 * @var TMemoryBuffer
+	 */
+	protected $_transport;
+
+	/**
+	 * @var TBinaryProtocol
+	 */
+	protected $_protocol;
+
+	/**
+	 * @param string $queue
+	 * @param array $options
+	 * @return void
+	 */
+	public function __construct($queue, $options = array()) {
+		require_once 'Thrift/protocol/TBinaryProtocol.php';
+		require_once 'Thrift/transport/TMemoryBuffer.php';
+		$protocolFactory = new TBinaryProtocolFactory();
+		$this->_transport = new TMemoryBuffer();
+		$this->_protocol = $protocolFactory->getProtocol($this->_transport);
+		parent::__construct($queue, $options);
+	}
+
+	/**
+	 * @param object $message
+	 * @return string
+	 */
+	protected function translate($message) {
+		$message->write($this->_protocol);
+		return $this->_transport->read($this->_transport->available());
+	}
+}

--- a/lib/php/jp/worker/Interface.php
+++ b/lib/php/jp/worker/Interface.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @package jp.worker
+ */
+interface jp_worker_Interface {
+	/**
+	 * @abstract
+	 * @throws Exception
+	 * @param string $item
+	 * @return bool
+	 */
+	public function processItem($item);
+}

--- a/tests/lib/php/jp/test/BaseTestCase.php
+++ b/tests/lib/php/jp/test/BaseTestCase.php
@@ -1,0 +1,15 @@
+<?php
+
+$GLOBALS['THRIFT_ROOT'] = 'Thrift';
+$jpRoot = dirname(__FILE__) . '/../../../../../';
+set_include_path(get_include_path() . PATH_SEPARATOR . $jpRoot . 'lib/php' . PATH_SEPARATOR . $jpRoot . 'gen-php/jp');
+require_once 'PHPUnit/Framework/TestCase.php';
+require_once $jpRoot . 'gen-php/jp/JobPool.php';
+require_once $jpRoot . 'gen-php/jp/jp_types.php';
+
+/**
+ * @package jp.test
+ */
+class jp_test_BaseTestCase extends PHPUnit_Framework_TestCase {
+	// Empty for now.
+}

--- a/tests/lib/php/jp/test/TestSuite.php
+++ b/tests/lib/php/jp/test/TestSuite.php
@@ -1,0 +1,24 @@
+<?php
+
+require_once 'PHPUnit/Framework/TestSuite.php';
+
+/**
+ * @package jp.test
+ */
+class jp_test_TestSuite {
+	/**
+	 * @static
+	 * @return void
+	 */
+	public static function suite() {
+		$suite = new PHPUnit_Framework_TestSuite('jp');
+		$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(dirname(__FILE__)), RecursiveIteratorIterator::SELF_FIRST);
+
+		/** @var $file DirectoryIterator */
+		foreach ($iterator as $file) {
+			if($file->isFile() && substr($file->getPathname(), -8) === 'Test.php') $suite->addTestFile($file->getPathname());
+		}
+
+		return $suite;
+	}
+}

--- a/tests/lib/php/jp/test/consumer/ConsumerTestCase.php
+++ b/tests/lib/php/jp/test/consumer/ConsumerTestCase.php
@@ -1,0 +1,31 @@
+<?php
+
+require_once dirname(__FILE__) . '/../BaseTestCase.php';
+$jpRoot = dirname(__FILE__) . '/../../../../../../';
+require_once $jpRoot . 'lib/php/jp/worker/Interface.php';
+
+/**
+ * @package jp.test.consumer
+ */
+class jp_test_consumer_ConsumerTestCase extends jp_test_BaseTestCase {
+	/**
+	 * @var array
+	 */
+	protected $queue = array();
+
+	/**
+	 * @return PHPUnit_Framework_MockObject_MockObject|Job
+	 */
+	public function mockAcquire() {
+		if(count($this->queue) === 0) throw new EmptyPool();
+		return array_shift($this->queue);
+	}
+
+	/**
+	 * @param string $message
+	 * @return void
+	 */
+	protected function addToQueueBackend($message) {
+		$this->queue[] = $message;
+	}
+}

--- a/tests/lib/php/jp/test/consumer/JsonTest.php
+++ b/tests/lib/php/jp/test/consumer/JsonTest.php
@@ -1,0 +1,40 @@
+<?php
+
+$jpRoot = dirname(__FILE__) . '/../../../../../../';
+require_once $jpRoot . 'lib/php/jp/consumer/Json.php';
+require_once 'ConsumerTestCase.php';
+
+/**
+ * @package jp.test.consumer
+ */
+class jp_test_consumer_JsonTest extends jp_test_consumer_ConsumerTestCase {
+	/**
+	 * @return void
+	 */
+	public function testRun() {
+		/** @var $worker PHPUnit_Framework_MockObject_MockObject|jp_worker_Interface */
+		$worker = $this->getMock('jp_worker_Interface');
+		$worker->expects($this->exactly(5)) // expect 5 calls
+			   ->method('processItem')
+			   ->with($this->arrayHasKey('foo'))
+			   ->will($this->returnValue(true));
+
+		/** @var $client PHPUnit_Framework_MockObject_MockObject|JobPoolIf */
+		$client = $this->getMock('JobPoolIf');
+		$client->expects($this->exactly(6)) // expect 6 calls (the 6th will result in an exception)
+			   ->method('acquire')
+			   ->will($this->returnCallback(array($this, 'mockAcquire')));
+
+		// Fill a mock queue backend
+		for($i = 0; $i < 5; $i++) {
+			/** @var $job PHPUnit_Framework_MockObject_MockObject|Job */
+			$job = $this->getMock('Job');
+			$job->message = json_encode(array('foo' => 'foo-' . $i));
+			$job->id = $i;
+			$this->addToQueueBackend($job);
+		}
+
+		$consumer = new jp_consumer_Json('foo', array('client' => $client, 'poll_interval' => 0), $worker);
+		$this->assertEquals(5, $consumer->run());
+	}
+}

--- a/tests/lib/php/jp/test/consumer/TextTest.php
+++ b/tests/lib/php/jp/test/consumer/TextTest.php
@@ -1,0 +1,40 @@
+<?php
+
+$jpRoot = dirname(__FILE__) . '/../../../../../../';
+require_once $jpRoot . 'lib/php/jp/consumer/Text.php';
+require_once 'ConsumerTestCase.php';
+
+/**
+ * @package jp.test.consumer
+ */
+class jp_test_consumer_TextTest extends jp_test_consumer_ConsumerTestCase {
+	/**
+	 * @return void
+	 */
+	public function testRun() {
+		/** @var $worker PHPUnit_Framework_MockObject_MockObject|jp_worker_Interface */
+		$worker = $this->getMock('jp_worker_Interface');
+		$worker->expects($this->exactly(5)) // expect 5 calls
+			   ->method('processItem')
+			   ->with($this->stringContains('foo'))
+			   ->will($this->returnValue(true));
+
+		/** @var $client PHPUnit_Framework_MockObject_MockObject|JobPoolIf */
+		$client = $this->getMock('JobPoolIf');
+		$client->expects($this->exactly(6)) // expect 6 calls (the 6th will result in an exception)
+			   ->method('acquire')
+			   ->will($this->returnCallback(array($this, 'mockAcquire')));
+
+		// Fill a mock queue backend
+		for($i = 0; $i < 5; $i++) {
+			/** @var $job PHPUnit_Framework_MockObject_MockObject|Job */
+			$job = $this->getMock('Job');
+			$job->message = 'foo-' . $i;
+			$job->id = $i;
+			$this->addToQueueBackend($job);
+		}
+
+		$consumer = new jp_consumer_Text('foo', array('client' => $client, 'poll_interval' => 0), $worker);
+		$this->assertEquals(5, $consumer->run());
+	}
+}

--- a/tests/lib/php/jp/test/consumer/ThriftTest.php
+++ b/tests/lib/php/jp/test/consumer/ThriftTest.php
@@ -1,0 +1,53 @@
+<?php
+
+$jpRoot = dirname(__FILE__) . '/../../../../../../';
+require_once $jpRoot . 'lib/php/jp/consumer/Thrift.php';
+require_once $jpRoot . 'examples/gen-php/example/example_types.php';
+require_once 'Thrift/protocol/TBinaryProtocol.php';
+require_once 'Thrift/transport/TMemoryBuffer.php';
+require_once 'ConsumerTestCase.php';
+
+/**
+ * @package jp.test.consumer
+ */
+class jp_test_consumer_ThriftTest extends jp_test_consumer_ConsumerTestCase {
+	/**
+	 * @return void
+	 */
+	public function testRun() {
+		/** @var $worker PHPUnit_Framework_MockObject_MockObject|jp_worker_Interface */
+		$worker = $this->getMock('jp_worker_Interface');
+		$worker->expects($this->exactly(5)) // expect 5 calls
+			   ->method('processItem')
+			   ->with($this->isInstanceOf('ExampleData'))
+			   ->will($this->returnValue(true));
+
+		/** @var $client PHPUnit_Framework_MockObject_MockObject|JobPoolIf */
+		$client = $this->getMock('JobPoolIf');
+		$client->expects($this->exactly(6)) // expect 6 calls (the 6th will result in an exception)
+			   ->method('acquire')
+			   ->will($this->returnCallback(array($this, 'mockAcquire')));
+
+		$protocolFactory = new TBinaryProtocolFactory();
+		$transport = new TMemoryBuffer();
+		$protocol = $protocolFactory->getProtocol($transport);
+
+		// Fill a mock queue backend
+		for($i = 0; $i < 5; $i++) {
+			/** @var $job PHPUnit_Framework_MockObject_MockObject|Job */
+			$job = $this->getMock('Job');
+			$doc = new ExampleData();
+			$doc->language = 'php';
+			$doc->api = 'simple' . $i;
+			$doc->format = 'thrift';
+			$doc->write($protocol);
+			$message = $transport->read($transport->available());
+			$job->message = $message;
+			$job->id = $i;
+			$this->addToQueueBackend($job);
+		}
+
+		$consumer = new jp_consumer_Thrift('foo', array('client' => $client, 'poll_interval' => 0), $worker, 'ExampleData');
+		$this->assertEquals(5, $consumer->run());
+	}
+}

--- a/tests/lib/php/jp/test/producer/JsonTest.php
+++ b/tests/lib/php/jp/test/producer/JsonTest.php
@@ -1,0 +1,26 @@
+<?php
+
+require_once dirname(__FILE__) . '/../BaseTestCase.php';
+$jpRoot = dirname(__FILE__) . '/../../../../../../';
+require_once $jpRoot . 'lib/php/jp/producer/Json.php';
+
+/**
+ * @package jp.test.producer
+ */
+class jp_test_producer_JsonTest extends jp_test_BaseTestCase {
+	/**
+	 * @return void
+	 */
+	public function testAdd() {
+		$message = array('foo' => 'bar', 'baz');
+
+		/** @var $client PHPUnit_Framework_MockObject_MockObject|JobPoolIf */
+		$client = $this->getMock('JobPoolIf');
+		$client->expects($this->once())
+			   ->method('add')
+			   ->with($this->equalTo('foo'), $this->equalTo(json_encode($message)));
+
+		$consumer = new jp_producer_Json('foo', array('client' => $client));
+		$consumer->add($message);
+	}
+}

--- a/tests/lib/php/jp/test/producer/TextTest.php
+++ b/tests/lib/php/jp/test/producer/TextTest.php
@@ -1,0 +1,26 @@
+<?php
+
+require_once dirname(__FILE__) . '/../BaseTestCase.php';
+$jpRoot = dirname(__FILE__) . '/../../../../../../';
+require_once $jpRoot . 'lib/php/jp/producer/Text.php';
+
+/**
+ * @package jp.test.producer
+ */
+class jp_test_producer_TextTest extends jp_test_BaseTestCase {
+	/**
+	 * @return void
+	 */
+	public function testAdd() {
+		$message = 'foo bar baz';
+
+		/** @var $client PHPUnit_Framework_MockObject_MockObject|JobPoolIf */
+		$client = $this->getMock('JobPoolIf');
+		$client->expects($this->once())
+			   ->method('add')
+			   ->with($this->equalTo('foo'), $this->equalTo($message));
+
+		$consumer = new jp_producer_Text('foo', array('client' => $client));
+		$consumer->add($message);
+	}
+}

--- a/tests/lib/php/jp/test/producer/ThriftTest.php
+++ b/tests/lib/php/jp/test/producer/ThriftTest.php
@@ -1,0 +1,38 @@
+<?php
+
+require_once dirname(__FILE__) . '/../BaseTestCase.php';
+$jpRoot = dirname(__FILE__) . '/../../../../../../';
+require_once $jpRoot . 'lib/php/jp/producer/Thrift.php';
+require_once $jpRoot . 'examples/gen-php/example/example_types.php';
+require_once 'Thrift/protocol/TBinaryProtocol.php';
+require_once 'Thrift/transport/TMemoryBuffer.php';
+
+/**
+ * @package jp.test.producer
+ */
+class jp_test_producer_ThriftTest extends jp_test_BaseTestCase {
+	/**
+	 * @return void
+	 */
+	public function testAdd() {
+		$doc = new ExampleData();
+		$doc->language = 'php';
+		$doc->api = 'simple';
+		$doc->format = 'thrift';
+
+		$protocolFactory = new TBinaryProtocolFactory();
+		$transport = new TMemoryBuffer();
+		$protocol = $protocolFactory->getProtocol($transport);
+		$doc->write($protocol);
+		$message = $transport->read($transport->available());
+
+		/** @var $client PHPUnit_Framework_MockObject_MockObject|JobPoolIf */
+		$client = $this->getMock('JobPoolIf');
+		$client->expects($this->once())
+			   ->method('add')
+			   ->with($this->equalTo('foo'), $this->equalTo($message));
+
+		$consumer = new jp_producer_Thrift('foo', array('client' => $client));
+		$consumer->add($doc);
+	}
+}


### PR DESCRIPTION
Implemented PHP producer and consumer libraries for the "Text", "JSON" and "Thrift" flavours. Examples have been added for all of those flavours, as well as a direct text add example. Unit tests implemented with PHPUnit, testing the producers and consumers.
